### PR TITLE
feat: Vietnamese docs and GUI example

### DIFF
--- a/README_vi.md
+++ b/README_vi.md
@@ -1,0 +1,106 @@
+# mijiaAPI
+
+API Python để điều khiển các thiết bị trong hệ sinh thái **Xiaomi Mijia**.
+
+[![GitHub](https://img.shields.io/badge/GitHub-Do1e%2Fmijia--api-blue)](https://github.com/Do1e/mijia-api)
+[![PyPI](https://img.shields.io/badge/PyPI-mijiaAPI-blue)](https://pypi.org/project/mijiaAPI/)
+[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-green.svg)](https://opensource.org/licenses/GPL-3.0)
+
+## ⚠️ Lưu ý quan trọng
+
+**Từ phiên bản v1.5.0 trở đi dự án có nhiều thay đổi phá vỡ tương thích.**
+Nếu bạn đang nâng cấp từ phiên bản cũ hãy đọc kỹ [CHANGELOG.md](CHANGELOG.md).
+
+## Cài đặt
+
+### Từ PyPI (khuyến nghị)
+
+```bash
+pip install mijiaAPI
+```
+
+### Cài từ mã nguồn
+
+```bash
+git clone https://github.com/Do1e/mijia-api.git
+cd mijia-api
+pip install .
+# hoặc `pip install -e .` để cài dạng editable
+```
+
+Sử dụng poetry:
+
+```bash
+poetry install
+```
+
+### AUR
+
+Nếu dùng Arch Linux có thể cài qua AUR:
+
+```bash
+yay -S python-mijia-api
+```
+
+## Sử dụng
+
+Các ví dụ đầy đủ nằm trong thư mục `demos`. Dưới đây là hướng dẫn cơ bản.
+
+### Đăng nhập
+
+`mijiaLogin` hỗ trợ đăng nhập tài khoản Mi:
+
+* `QRlogin() -> dict`: quét mã QR đăng nhập.
+* `login(username, password) -> dict`: đăng nhập bằng tài khoản/mật khẩu.
+
+### API chính
+
+`mijiaAPI` sử dụng dữ liệu trả về từ `mijiaLogin` để điều khiển thiết bị.
+Một số phương thức:
+
+* `get_devices_list()` – lấy danh sách thiết bị.
+* `get_homes_list()` – lấy danh sách nhà/phòng.
+* `get_scenes_list(home_id)` – lấy các kịch bản thủ công.
+* `run_scene(scene_id)` – thực thi kịch bản.
+* `get_devices_prop(data)` / `set_devices_prop(data)` – lấy/đặt thuộc tính.
+* `run_action(data)` – thực thi hành động cụ thể.
+
+### Bao gói thiết bị
+
+`mijiaDevice` cung cấp giao diện thân thiện hơn cho việc điều khiển. Ví dụ:
+
+```python
+device = mijiaDevice(api, dev_name='Đèn')
+device.on = True
+device.brightness = 60
+```
+
+### CLI
+
+Có thể sử dụng ngay trên dòng lệnh:
+
+```bash
+mijiaAPI --help
+mijiaAPI get --dev_name Tên --prop_name Thuộc_tính
+mijiaAPI set --dev_name Tên --prop_name Thuộc_tính --value Giá_trị
+```
+
+## Giao diện đồ họa
+
+Thư mục `demos` chứa ví dụ `gui.py` minh họa đăng nhập bằng QR và liệt kê thiết
+bị thông qua Tkinter.
+
+## Ghi công
+
+* [janzlan/mijia-api](https://gitee.com/janzlan/mijia-api/tree/master)
+
+## Giấy phép
+
+Phát hành theo giấy phép [GPL-3.0](LICENSE).
+
+## Miễn trừ trách nhiệm
+
+* Dự án chỉ phục vụ mục đích học tập, không sử dụng cho mục đích thương mại.
+* Người dùng tự chịu trách nhiệm với mọi rủi ro khi sử dụng.
+* Tác giả không chịu trách nhiệm cho bất kỳ thiệt hại nào phát sinh.
+

--- a/demos/gui.py
+++ b/demos/gui.py
@@ -1,0 +1,55 @@
+"""Ví dụ giao diện đồ họa đơn giản cho mijiaAPI.
+
+Cho phép đăng nhập bằng mã QR và hiển thị danh sách thiết bị.
+"""
+
+import tkinter as tk
+from tkinter import messagebox
+
+from mijiaAPI import mijiaLogin, mijiaAPI
+
+
+class MijiaGUI(tk.Tk):
+    """Cửa sổ chính của ứng dụng."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Mijia API GUI")
+        self.api: mijiaAPI | None = None
+
+        tk.Button(self, text="Đăng nhập bằng QR", command=self.login_qr).pack(pady=5)
+        tk.Button(self, text="Lấy danh sách thiết bị", command=self.list_devices).pack(pady=5)
+
+        self.text = tk.Text(self, width=60, height=20)
+        self.text.pack(padx=5, pady=5)
+
+    def login_qr(self) -> None:
+        """Đăng nhập tài khoản Mi thông qua mã QR."""
+
+        login = mijiaLogin()
+        try:
+            auth = login.QRlogin()
+            self.api = mijiaAPI(auth)
+            messagebox.showinfo("Thông báo", "Đăng nhập thành công")
+        except Exception as exc:  # pragma: no cover - phụ thuộc môi trường
+            messagebox.showerror("Lỗi", str(exc))
+
+    def list_devices(self) -> None:
+        """Lấy và hiển thị danh sách thiết bị."""
+
+        if not self.api:
+            messagebox.showwarning("Cảnh báo", "Vui lòng đăng nhập trước")
+            return
+        try:
+            devices = self.api.get_devices_list()
+            self.text.delete("1.0", tk.END)
+            for dev in devices:
+                self.text.insert(tk.END, f"{dev['name']} ({dev['model']})\n")
+        except Exception as exc:  # pragma: no cover - phụ thuộc môi trường
+            messagebox.showerror("Lỗi", str(exc))
+
+
+if __name__ == "__main__":
+    app = MijiaGUI()
+    app.mainloop()
+

--- a/mijiaAPI/apis.py
+++ b/mijiaAPI/apis.py
@@ -11,13 +11,14 @@ from .utils import post_data
 class mijiaAPI(object):
     def __init__(self, auth_data: dict):
         """
-        初始化mijiaAPI对象。
+        Khởi tạo đối tượng **mijiaAPI**.
 
         Args:
-            auth_data (dict): 包含授权信息的字典，必须包含'userId'、'deviceId'、'ssecurity'和'serviceToken'。
+            auth_data (dict): Từ điển chứa thông tin ủy quyền, bắt buộc phải có
+            ``userId``, ``deviceId``, ``ssecurity`` và ``serviceToken``.
 
         Raises:
-            Exception: 当授权数据不完整时抛出异常。
+            Exception: Ném ra khi dữ liệu ủy quyền không đầy đủ.
         """
         if any(k not in auth_data for k in ['userId', 'deviceId', 'ssecurity', 'serviceToken']):
             raise Exception('授权数据无效')
@@ -42,10 +43,10 @@ class mijiaAPI(object):
     @property
     def available(self) -> bool:
         """
-        检查API是否可用。
+        Kiểm tra tính khả dụng của API.
 
         Returns:
-            bool: API可用返回True，否则返回False。
+            bool: ``True`` nếu API vẫn còn hiệu lực, ngược lại ``False``.
         """
         if self.expireTime:
             expire_time = datetime.strptime(self.expireTime, '%Y-%m-%d %H:%M:%S')
@@ -56,10 +57,10 @@ class mijiaAPI(object):
 
     def get_devices_list(self) -> list:
         """
-        获取设备列表。
+        Lấy danh sách thiết bị.
 
         Returns:
-            dict: 设备列表。
+            dict: Danh sách thiết bị.
         """
         uri = '/home/home_device_list'
         home_list = self.get_homes_list()
@@ -89,10 +90,10 @@ class mijiaAPI(object):
 
     def get_homes_list(self) -> list:
         """
-        获取家庭列表。
+        Lấy danh sách "nhà".
 
         Returns:
-            list: 家庭列表，包括房间信息。
+            list: Danh sách nhà bao gồm thông tin phòng.
         """
         uri = '/v2/homeroom/gethome_merged'
         data = {"fg": True, "fetch_share": True, "fetch_share_dev": True, "limit": 300, "app_ver": 7}
@@ -100,15 +101,16 @@ class mijiaAPI(object):
 
     def get_scenes_list(self, home_id: str) -> list:
         """
-        获取场景列表。
+        Lấy danh sách kịch bản (scene).
 
-        在米家APP中通过"添加 -> 手动控制"设置。
+        Các kịch bản được thiết lập trong ứng dụng Mi Home qua
+        "Thêm -> Điều khiển thủ công".
 
         Args:
-            home_id (str): 家庭ID，从get_homes_list获取。
+            home_id (str): ID của nhà, lấy từ ``get_homes_list``.
 
         Returns:
-            list: 场景列表。
+            list: Danh sách kịch bản.
         """
         uri = '/appgateway/miot/appsceneservice/AppSceneService/GetSceneList'
         data = {"home_id": home_id}
@@ -119,13 +121,13 @@ class mijiaAPI(object):
 
     def run_scene(self, scene_id: str) -> bool:
         """
-        运行场景。
+        Chạy một kịch bản đã định nghĩa.
 
         Args:
-            scene_id (str): 场景ID，从get_scenes_list获取。
+            scene_id (str): ID của kịch bản, lấy từ ``get_scenes_list``.
 
         Returns:
-            bool: 操作结果。
+            bool: Kết quả thực thi.
         """
         uri = '/appgateway/miot/appsceneservice/AppSceneService/RunScene'
         data = {"scene_id": scene_id, "trigger_key": "user.click"}
@@ -133,14 +135,15 @@ class mijiaAPI(object):
 
     def get_consumable_items(self, home_id: str, owner_id: Optional[int] = None) -> list:
         """
-        获取耗材列表。
+        Lấy danh sách vật tư tiêu hao của thiết bị.
 
         Args:
-            home_id (str): 家庭ID，从get_homes_list获取。
-            owner_id (str, optional): 用户ID，默认为None，如果`home_id`为共享家庭，则需要提供owner_id。
+            home_id (str): ID của nhà, lấy từ ``get_homes_list``.
+            owner_id (str, optional): ID người dùng, cần thiết nếu ``home_id``
+            thuộc nhà được chia sẻ.
 
         Returns:
-            list: 耗材列表。
+            list: Danh sách vật tư.
         """
         uri = '/v2/home/standard_consumable_items'
         data = {"home_id": int(home_id), "owner_id": int(owner_id) if owner_id else self.userId}
@@ -151,22 +154,23 @@ class mijiaAPI(object):
 
     def get_devices_prop(self, data: list) -> list:
         """
-        获取设备属性。
+        Lấy thuộc tính của thiết bị.
 
         Args:
-            data (list): 设备属性请求列表，每项为包含以下键的字典：
-                - did: 设备ID，从get_devices_list获取
-                - siid: 服务ID，从 https://home.miot-spec.com/spec/{model} 获取，model从get_devices_list获取
-                - piid: 属性ID，从 https://home.miot-spec.com/spec/{model} 获取，model从get_devices_list获取
+            data (list): Danh sách yêu cầu thuộc tính, mỗi phần tử là một
+            dict gồm các khóa:
+                - did: ID thiết bị, lấy từ ``get_devices_list``
+                - siid: ID dịch vụ, tra cứu tại https://home.miot-spec.com/spec/{model}
+                - piid: ID thuộc tính, tra cứu tương tự
 
-                示例(yeelink.light.lamp4)：
+                Ví dụ (yeelink.light.lamp4):
                 [
-                    {"did": "1234567890", "siid": 2, "piid": 2}, # 获取亮度
-                    {"did": "1234567890", "siid": 2, "piid": 3}, # 获取色温
+                    {"did": "1234567890", "siid": 2, "piid": 2}, # độ sáng
+                    {"did": "1234567890", "siid": 2, "piid": 3}, # nhiệt độ màu
                 ]
 
         Returns:
-            list: 设备属性信息列表。
+            list: Thông tin thuộc tính của thiết bị.
         """
         uri = '/miotspec/prop/get'
         data = {"params": data}
@@ -174,23 +178,23 @@ class mijiaAPI(object):
 
     def set_devices_prop(self, data: list) -> list:
         """
-        设置设备属性。
+        Thiết lập thuộc tính cho thiết bị.
 
         Args:
-            data (list): 设备属性设置列表，每项为包含以下键的字典：
-                - did: 设备ID，从get_devices_list获取
-                - siid: 服务ID，从 https://home.miot-spec.com/spec/{model} 获取，model从get_devices_list获取
-                - piid: 属性ID，从 https://home.miot-spec.com/spec/{model} 获取，model从get_devices_list获取
-                - value: 要设置的值
+            data (list): Danh sách thuộc tính cần đặt, mỗi phần tử gồm:
+                - did: ID thiết bị
+                - siid: ID dịch vụ
+                - piid: ID thuộc tính
+                - value: Giá trị cần thiết lập
 
-                示例(yeelink.light.lamp4)：
+                Ví dụ (yeelink.light.lamp4):
                 [
-                    {"did": "1234567890", "siid": 2, "piid": 2, "value": 50},  # 设置亮度为50%
-                    {"did": "1234567890", "siid": 2, "piid": 3, "value": 2700} # 设置色温为2700K
+                    {"did": "1234567890", "siid": 2, "piid": 2, "value": 50},  # đặt độ sáng 50%
+                    {"did": "1234567890", "siid": 2, "piid": 3, "value": 2700} # đặt nhiệt độ màu 2700K
                 ]
 
         Returns:
-            list: 操作结果。
+            list: Kết quả thao tác.
         """
         uri = '/miotspec/prop/set'
         data = {"params": data}
@@ -198,20 +202,21 @@ class mijiaAPI(object):
 
     def run_action(self, data: dict) -> dict:
         """
-        执行设备动作。
+        Thực thi một hành động của thiết bị.
 
         Args:
-            data (dict): 动作请求，包含以下键：
-                - did: 设备ID，从get_devices_list获取
-                - siid: 服务ID，从 https://home.miot-spec.com/spec/{model} 获取，model从get_devices_list获取
-                - aiid: 动作ID，从 https://home.miot-spec.com/spec/{model} 获取，model从get_devices_list获取
-                - value: 参数列表
+            data (dict): Yêu cầu hành động với các khóa:
+                - did: ID thiết bị
+                - siid: ID dịch vụ
+                - aiid: ID hành động
+                - value: Danh sách tham số
 
-                示例(xiaomi.feeder.pi2001)：
-                {"did": "1234567890", "siid": 2, "aiid": 1, "value": [2]} # 远程喂食2份
+                Ví dụ (xiaomi.feeder.pi2001):
+                {"did": "1234567890", "siid": 2, "aiid": 1, "value": [2]}
+                # cho ăn 2 phần từ xa
 
         Returns:
-            dict: 操作结果。
+            dict: Kết quả hành động.
         """
         uri = '/miotspec/action'
         data = {"params": data}
@@ -219,22 +224,22 @@ class mijiaAPI(object):
 
     def get_statistics(self, data: dict) -> list:
         """
-        获取设备的统计信息。
+        Lấy số liệu thống kê của thiết bị.
 
         Args:
-            data (dict): 请求参数，包含以下键：
-                - did: 设备ID，从get_devices_list获取
-                - key: siid.piid，表示要获取统计数据的属性
-                - data_type: 统计类型，可选值包括：
-                    - 'stat_hour_v3': 按小时统计
-                    - 'stat_day_v3': 按天统计
-                    - 'stat_week_v3': 按周统计
-                    - 'stat_month_v3': 按月统计
-                - limit: 返回的最大条目数，可选参数
-                - time_start: 开始时间戳，单位为秒
-                - time_end: 结束时间戳，单位为秒
+            data (dict): Tham số yêu cầu gồm:
+                - did: ID thiết bị
+                - key: ``siid.piid`` chỉ ra thuộc tính cần thống kê
+                - data_type: Loại thống kê, có thể là:
+                    - 'stat_hour_v3': theo giờ
+                    - 'stat_day_v3': theo ngày
+                    - 'stat_week_v3': theo tuần
+                    - 'stat_month_v3': theo tháng
+                - limit: Số mục tối đa trả về
+                - time_start: Thời điểm bắt đầu (timestamp, giây)
+                - time_end: Thời điểm kết thúc (timestamp, giây)
 
-                示例(lumi.acpartner.mcn04 的 power-consumption)：
+                Ví dụ (lumi.acpartner.mcn04 - power-consumption):
                 {
                     "did": "1234567890",
                     "key": "7.1",
@@ -242,10 +247,10 @@ class mijiaAPI(object):
                     "limit": 24,
                     "time_start": 1685548800,
                     "time_end": 1750694400,
-                } # 2023-06-01 00:00:00 到 2025-06-24 00:00:00 的月度统计数据
+                } # Dữ liệu theo tháng từ 2023-06-01 đến 2025-06-24
 
         Returns:
-            list: 统计信息列表。
+            list: Danh sách dữ liệu thống kê.
         """
         uri = '/v2/user/statistics'
         return self._post_process(post_data(self.session, self.ssecurity, uri, data))

--- a/mijiaAPI/devices.py
+++ b/mijiaAPI/devices.py
@@ -14,13 +14,13 @@ logger = get_logger(__name__)
 class DevProp(object):
     def __init__(self, prop_dict: dict):
         """
-        初始化属性对象。
+        Khởi tạo đối tượng thuộc tính.
 
         Args:
-            prop_dict (dict): 属性字典。
+            prop_dict (dict): Từ điển mô tả thuộc tính.
 
         Raises:
-            ValueError: 如果属性类型不受支持。
+            ValueError: Nếu kiểu thuộc tính không được hỗ trợ.
         """
         self.name = prop_dict['name']
         self.desc = prop_dict['description']
@@ -35,10 +35,10 @@ class DevProp(object):
 
     def __str__(self):
         """
-        返回属性的字符串表示。
+        Trả về chuỗi biểu diễn của thuộc tính.
 
         Returns:
-            str: 属性的名称、描述、类型、读写权限、单位和范围。
+            str: Tên, mô tả, kiểu, quyền đọc/ghi, đơn vị và phạm vi.
         """
         lines = [
             f"  {self.name}: {self.desc}",
@@ -55,10 +55,10 @@ class DevProp(object):
 class DevAction(object):
     def __init__(self, act_dict: dict):
         """
-        初始化动作对象。
+        Khởi tạo đối tượng hành động.
 
         Args:
-            act_dict (dict): 动作字典。
+            act_dict (dict): Từ điển mô tả hành động.
         """
         self.name = act_dict['name']
         self.desc = act_dict['description']
@@ -66,10 +66,10 @@ class DevAction(object):
 
     def __str__(self):
         """
-        返回动作的字符串表示。
+        Trả về chuỗi biểu diễn của hành động.
 
         Returns:
-            str: 动作的名称和描述。
+            str: Tên và mô tả của hành động.
         """
         return f'  {self.name}: {self.desc}'
 
@@ -84,26 +84,29 @@ class mijiaDevice(object):
             sleep_time: Optional[Union[int, float]] = 0.5
     ):
         """
-        初始化设备对象。
+        Khởi tạo đối tượng thiết bị.
 
-        如果未提供设备信息，则根据设备名称获取设备信息。如果两者均未提供，则抛出异常。
-        如果同时提供了设备信息和设备名称，则以设备信息为准。
+        Nếu không cung cấp thông tin thiết bị, hệ thống sẽ tìm theo tên. Cần
+        cung cấp ``dev_info`` hoặc ``dev_name`` ít nhất một trong hai. Nếu cả hai
+        được cung cấp thì ưu tiên ``dev_info``.
 
         Args:
-            api (mijiaAPI): 米家API对象。
-            dev_info (dict, optional): 设备信息字典，从get_device_info获取。默认为None。
-            dev_name (str, optional): 设备名称，从get_devices_list获取。默认为None。
-            did (str, optional): 设备ID，如未指定，则需要在调用get/set时指定。默认为None。
-            sleep_time ([int, float], optional): 调用设备属性的间隔时间。默认为0.5秒。
+            api (mijiaAPI): Đối tượng API.
+            dev_info (dict, optional): Thông tin thiết bị từ ``get_device_info``.
+            dev_name (str, optional): Tên thiết bị từ ``get_devices_list``.
+            did (str, optional): ID thiết bị; nếu không cung cấp phải chỉ định
+            khi gọi ``get/set``.
+            sleep_time ([int, float], optional): Thời gian nghỉ giữa các lần gọi,
+            mặc định 0.5 giây.
 
         Raises:
-            RuntimeError: 如果dev_info和dev_name都未提供。
-            ValueError: 如果找不到指定设备或找到多个同名设备。
+            RuntimeError: Khi thiếu cả ``dev_info`` và ``dev_name``.
+            ValueError: Khi không tìm thấy thiết bị hoặc có nhiều thiết bị trùng tên.
 
         Note:
-            - 如果同时提供了dev_info和dev_name，则以dev_info为准。
-            - 如果只提供了dev_name，则根据名称自动获取设备信息。
-            - 如果只提供了dev_info，则直接使用该信息。
+            - Nếu cung cấp cả ``dev_info`` và ``dev_name`` sẽ ưu tiên ``dev_info``.
+            - Nếu chỉ có ``dev_name`` sẽ tự động tra cứu thông tin thiết bị.
+            - Nếu chỉ có ``dev_info`` sẽ dùng trực tiếp thông tin đó.
         """
         if dev_info is None and dev_name is None:
             raise RuntimeError("必须提供 'dev_info' 或 'dev_name' 中的一个参数。")
@@ -141,10 +144,10 @@ class mijiaDevice(object):
 
     def __str__(self) -> str:
         """
-        返回设备的字符串表示。
+        Trả về chuỗi biểu diễn của thiết bị.
 
         Returns:
-            str: 设备的属性和动作列表。
+            str: Danh sách thuộc tính và hành động.
         """
         prop_list_str = '\n'.join(filter(None, (str(v) for k, v in self.prop_list.items() if '_' not in k)))
         action_list_str = '\n'.join(map(str, self.action_list.values()))
@@ -154,19 +157,20 @@ class mijiaDevice(object):
 
     def set(self, name: str, value: Union[bool, int, float, str], did: Optional[str] = None) -> bool:
         """
-        设置设备的属性值。
+        Thiết lập giá trị thuộc tính cho thiết bị.
 
         Args:
-            name (str): 属性名称。
-            value (Union[bool, int, float, str]): 属性值。
-            did (str, optional): 设备ID。如未指定，则使用实例化时的did。默认为None。
+            name (str): Tên thuộc tính.
+            value (Union[bool, int, float, str]): Giá trị cần thiết lập.
+            did (str, optional): ID thiết bị; nếu không có sẽ dùng giá trị khi
+            khởi tạo.
 
         Returns:
-            bool: 执行结果（True/False）。
+            bool: ``True`` nếu thành công.
 
         Raises:
-            ValueError: 如果属性不存在、属性为只读或值无效。
-            RuntimeError: 如果设置属性失败。
+            ValueError: Khi thuộc tính không tồn tại, chỉ đọc hoặc giá trị không hợp lệ.
+            RuntimeError: Khi thao tác thất bại.
         """
         if did is None:
             did = self.did
@@ -238,18 +242,18 @@ class mijiaDevice(object):
 
     def get(self, name: str, did: Optional[str] = None) -> Union[bool, int, float, str]:
         """
-        获取设备的属性值。
+        Lấy giá trị thuộc tính của thiết bị.
 
         Args:
-            name (str): 属性名称。
-            did (str, optional): 设备ID。如未指定，则使用实例化时的did。默认为None。
+            name (str): Tên thuộc tính.
+            did (str, optional): ID thiết bị, mặc định dùng khi khởi tạo.
 
         Returns:
-            Union[bool, int, float, str]: 属性值。
+            Union[bool, int, float, str]: Giá trị thuộc tính.
 
         Raises:
-            ValueError: 如果未指定设备ID、属性不存在或属性为只写。
-            RuntimeError: 如果获取属性失败。
+            ValueError: Khi không có ID thiết bị, thuộc tính không tồn tại hoặc chỉ ghi.
+            RuntimeError: Khi không thể lấy được thuộc tính.
         """
         if did is None:
             did = self.did
@@ -275,14 +279,15 @@ class mijiaDevice(object):
 
     def __setattr__(self, name: str, value: Union[bool, int, float, str]) -> None:
         """
-        设置设备的属性值（通过对象属性方式，需在实例化时指定did）。
+        Thiết lập thuộc tính thông qua cú pháp truy cập thuộc tính của đối tượng
+        (yêu cầu đã chỉ định ``did`` khi khởi tạo).
 
         Args:
-            name (str): 属性名称。
-            value (Union[bool, int, float, str]): 属性值。
+            name (str): Tên thuộc tính.
+            value (Union[bool, int, float, str]): Giá trị.
 
         Raises:
-            RuntimeError: 如果设置属性失败。
+            RuntimeError: Nếu thiết lập thất bại.
         """
         if 'prop_list' in self.__dict__ and name in self.prop_list:
             if not self.set(name, value):
@@ -292,13 +297,14 @@ class mijiaDevice(object):
 
     def __getattr__(self, name: str) -> Union[bool, int, float, str]:
         """
-        获取设备的属性值（通过对象属性方式，需在实例化时指定did）。
+        Lấy thuộc tính thông qua cú pháp truy cập thuộc tính của đối tượng
+        (yêu cầu đã chỉ định ``did`` khi khởi tạo).
 
         Args:
-            name (str): 属性名称。
+            name (str): Tên thuộc tính.
 
         Returns:
-            Union[bool, int, float, str]: 属性值。
+            Union[bool, int, float, str]: Giá trị thuộc tính.
         """
         if 'prop_list' in self.__dict__ and name in self.prop_list:
             return self.get(name)
@@ -313,20 +319,21 @@ class mijiaDevice(object):
             **kwargs
     ) -> bool:
         """
-        运行设备动作。
+        Thực thi một hành động trên thiết bị.
 
         Args:
-            name (str): 动作名称。
-            did (Optional[str], optional): 设备ID。如未指定，则使用实例化时的did。默认为None。
-            value (Optional[Union[list, tuple]], optional): 动作参数。如动作不需要参数，则不需指定。默认为None。
-            **kwargs: 其它动作参数，如智能音箱的in参数[run_action('execute-text-directive', _in=['空调调至26度', True])]。
+            name (str): Tên hành động.
+            did (Optional[str], optional): ID thiết bị, mặc định dùng khi khởi tạo.
+            value (Optional[Union[list, tuple]], optional): Tham số của hành động.
+            **kwargs: Tham số bổ sung, ví dụ loa thông minh với tham số
+            ``in`` [run_action('execute-text-directive', _in=['bật đèn', True])].
 
         Returns:
-            bool: 执行结果（True/False）。
+            bool: ``True`` nếu thành công.
 
         Raises:
-            ValueError: 如果未指定设备ID、动作不存在或参数无效。
-            RuntimeError: 如果运行动作失败。
+            ValueError: Khi thiếu ID thiết bị, hành động không tồn tại hoặc tham số sai.
+            RuntimeError: Khi thực thi hành động thất bại.
         """
         if did is None:
             did = self.did
@@ -360,17 +367,18 @@ class mijiaDevice(object):
 
 def get_device_info(device_model: str, cache_path: Optional[str] = os.path.join(os.path.expanduser("~"), ".config/mijia-api")) -> dict:
     """
-    获取设备信息，用于初始化mijiaDevice对象。
+    Lấy thông tin thiết bị để khởi tạo ``mijiaDevice``.
 
     Args:
-        device_model (str): 设备型号，从get_devices_list获取。
-        cache_path (str, optional): 缓存文件路径。默认为~/.config/mijia-api，设置为None则不使用缓存。
+        device_model (str): Model thiết bị từ ``get_devices_list``.
+        cache_path (str, optional): Đường dẫn cache, mặc định
+        ``~/.config/mijia-api``. Đặt ``None`` để bỏ cache.
 
     Returns:
-        dict: 设备信息字典。
+        dict: Từ điển thông tin thiết bị.
 
     Raises:
-        RuntimeError: 如果获取设备信息失败。
+        RuntimeError: Nếu lấy thông tin thiết bị thất bại.
     """
     if cache_path is not None:
         cache_file = os.path.join(cache_path, f'{device_model}.json')

--- a/mijiaAPI/login.py
+++ b/mijiaAPI/login.py
@@ -20,11 +20,11 @@ logger = get_logger(__name__)
 class LoginError(Exception):
     def __init__(self, code: int, message: str):
         """
-        初始化登录错误异常。
+        Khởi tạo ngoại lệ đăng nhập.
 
         Args:
-            code (int): 错误代码。
-            message (str): 错误消息。
+            code (int): Mã lỗi.
+            message (str): Thông báo lỗi.
         """
         self.code = code
         self.message = message
@@ -34,10 +34,11 @@ class LoginError(Exception):
 class mijiaLogin(object):
     def __init__(self, save_path: Optional[str] = None):
         """
-        初始化米家登录对象。
+        Khởi tạo đối tượng đăng nhập Mi Home.
 
         Args:
-            save_path (str, optional): 认证数据保存路径。默认为None。
+            save_path (str, optional): Đường dẫn lưu dữ liệu xác thực, mặc định
+            ``None``.
         """
         self.auth_data = None
         self.save_path = save_path
@@ -54,13 +55,13 @@ class mijiaLogin(object):
 
     def _get_index(self) -> dict[str, str]:
         """
-        获取索引页数据。
+        Lấy dữ liệu trang chỉ mục.
 
         Returns:
-            dict[str, str]: 包含设备ID和其他必要参数的字典。
+            dict[str, str]: Từ điển chứa ``deviceId`` và các tham số cần thiết.
 
         Raises:
-            LoginError: 请求索引页失败时抛出。
+            LoginError: Nếu yêu cầu trang chỉ mục thất bại.
         """
         ret = self.session.get(msgURL)
         if ret.status_code != 200:
@@ -75,16 +76,16 @@ class mijiaLogin(object):
 
     def _get_account_info(self, user_id: str) -> dict[str, str]:
         """
-        获取账户信息。
+        Lấy thông tin tài khoản.
 
         Args:
-            user_id (str): 用户ID。
+            user_id (str): ID người dùng.
 
         Returns:
-            dict[str, str]: 包含账户信息的字典。
+            dict[str, str]: Thông tin tài khoản.
 
         Raises:
-            LoginError: 获取账户信息失败时抛出。
+            LoginError: Khi không thể lấy thông tin tài khoản.
         """
         try:
             ret = self.session.get(accountURL + str(user_id))
@@ -98,16 +99,17 @@ class mijiaLogin(object):
     @staticmethod
     def _extract_latest_gmt_datetime(data: dict) -> datetime:
         """
-        提取过期时间并转换为中国时区。
+        Trích xuất thời điểm hết hạn và chuyển sang múi giờ Trung Quốc.
 
         Args:
-            data (dict): 用户凭证数据，包含GMT时间的键值对。
+            data (dict): Dữ liệu cookie chứa các cặp khóa thời gian GMT.
 
         Returns:
-            datetime: 转换后的中国时区时间。
+            datetime: Thời gian theo múi giờ Trung Quốc.
 
         Raises:
-            LoginError: 如果没有找到GMT时间键或解析失败，抛出登录错误。
+            LoginError: Nếu không tìm thấy khóa thời gian GMT hoặc phân tích
+            thất bại.
         """
 
         gmt_time_keys = [
@@ -121,15 +123,17 @@ class mijiaLogin(object):
         latest_utc_time = max(parsed_times)
         china_time = latest_utc_time + timedelta(hours=8)
 
-        # [FIXME] 实测此处的过期时间并不准确，实际过期时间可能大于此处获取的时间
-        #         cookie 中唯一用到的 serviceToken 并无过期时间
+        # [FIXME] Thực tế thời gian hết hạn tại đây không chính xác, có thể dài
+        #         hơn giá trị lấy được. serviceToken trong cookie không có
+        #         thời gian hết hạn rõ ràng.
         return china_time
 
     def _save_auth(self) -> None:
         """
-        保存认证数据到文件。
+        Lưu dữ liệu xác thực ra tệp.
 
-        如果设置了保存路径且有认证数据，则将其以JSON格式保存到指定路径。
+        Nếu thiết lập đường dẫn lưu và có dữ liệu, nội dung sẽ được ghi dưới
+        dạng JSON vào đường dẫn đó.
         """
         if self.save_path is not None and self.auth_data is not None:
             if not os.path.isabs(self.save_path):
@@ -146,17 +150,18 @@ class mijiaLogin(object):
 
     def login(self, username: str, password: str) -> dict:
         """
-        使用用户名和密码登录。
+        Đăng nhập bằng tài khoản và mật khẩu.
 
         Args:
-            username (str): 小米账户用户名（邮箱/手机号/小米ID）。
-            password (str): 小米账户密码。
+            username (str): Tên đăng nhập (email/điện thoại/ID Xiaomi).
+            password (str): Mật khẩu tài khoản.
 
         Returns:
-            dict: 授权数据，包含userId、ssecurity、deviceId和serviceToken。
+            dict: Dữ liệu ủy quyền gồm ``userId``, ``ssecurity``, ``deviceId``
+            và ``serviceToken``.
 
         Raises:
-            LoginError: 登录失败时抛出。
+            LoginError: Khi đăng nhập thất bại.
         """
         logger.warning('使用账号密码登录很可能需要验证码。请尝试使用 `QRlogin` 方法。')
         data = self._get_index()
@@ -200,11 +205,11 @@ class mijiaLogin(object):
     @staticmethod
     def _print_qr(loginurl: str, box_size: int = 10) -> None:
         """
-        打印并保存二维码。
+        In ra và lưu mã QR.
 
         Args:
-            loginurl (str): 包含登录信息的URL。
-            box_size (int, optional): 二维码大小。默认为10。
+            loginurl (str): URL chứa thông tin đăng nhập.
+            box_size (int, optional): Kích thước QR, mặc định 10.
         """
         logger.info('请使用米家APP扫描下方二维码')
         qr = QRCode(border=1, box_size=box_size)
@@ -221,13 +226,14 @@ class mijiaLogin(object):
 
     def QRlogin(self) -> dict:
         """
-        使用二维码登录。
+        Đăng nhập thông qua mã QR.
 
         Returns:
-            dict: 授权数据，包含userId、ssecurity、deviceId和serviceToken。
+            dict: Thông tin ủy quyền gồm ``userId``, ``ssecurity``, ``deviceId``
+            và ``serviceToken``.
 
         Raises:
-            LoginError: 登录失败时抛出。
+            LoginError: Nếu đăng nhập thất bại.
         """
         data = self._get_index()
         location = data['location']
@@ -285,7 +291,7 @@ class mijiaLogin(object):
 
     def __del__(self):
         """
-        析构函数，清理生成的二维码文件。
+        Hàm hủy, xóa tệp mã QR đã tạo.
         """
         if os.path.exists('qr.png'):
             os.remove('qr.png')


### PR DESCRIPTION
## Summary
- translate core code comments to Vietnamese
- add Vietnamese README and GUI demo using Tkinter

## Testing
- `python -m py_compile mijiaAPI/apis.py mijiaAPI/login.py mijiaAPI/devices.py demos/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb378eda5c832187515f024a256b73